### PR TITLE
docs: Fix README paths and standardize pre-commit flags

### DIFF
--- a/.claude/commands/ds-fix-precommit.md
+++ b/.claude/commands/ds-fix-precommit.md
@@ -1,12 +1,12 @@
 # Fix Pre-commit Issues
 
-**Goal**: All files pass `pre-commit run -a` with no remaining issues.
+**Goal**: All files pass `pre-commit run --all-files` with no remaining issues.
 
 ## Approach
 
 | Step | Action |
 |------|--------|
-| Run | `pre-commit run -a` |
+| Run | `pre-commit run --all-files` |
 | Auto-fix | `ruff check --fix` then `ruff format` on failing files |
 | Iterate | Re-run pre-commit until clean |
 

--- a/.claude/commands/ds-release.md
+++ b/.claude/commands/ds-release.md
@@ -20,7 +20,7 @@
 | Changelog | `[Unreleased]` section converted to `[X.Y.Z] - YYYY-MM-DD` |
 | Changelog content | Entries exist for this release |
 | New Unreleased | Empty `[Unreleased] - YYYY-MM-DD` section added above |
-| Pre-commit | `pre-commit run -a` passes |
+| Pre-commit | `pre-commit run --all-files` passes |
 | Tests | `pytest` passes for the package |
 
 ## Approach

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ When adding/modifying tools, update:
 
 | Tool Type | Files to Update |
 |-----------|-----------------|
-| MCP tools | `rossum_mcp/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
-| Agent tools | `rossum_agent/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
+| MCP tools | `rossum-mcp/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
+| Agent tools | `rossum-agent/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
 
 Include: tool name, description, parameters with types, return format with JSON examples.
 


### PR DESCRIPTION
## Summary
- Fix README paths in AGENTS.md/CLAUDE.md Documentation Updates section (rossum_mcp → rossum-mcp, rossum_agent → rossum-agent)
- Standardize pre-commit command to `--all-files` in ds-fix-precommit.md and ds-release.md for consistency with AGENTS.md

## Review Notes
- Coffee-time review (~3-5 min)
- Docs only

🤖 Generated with [Claude Code](https://claude.ai/code) daily suggestion