### PR TITLE
claude-commands: Move daily-suggestion-log to .claude/

### DIFF
--- a/.claude/commands/ds-daily-suggestion-feedback.md
+++ b/.claude/commands/ds-daily-suggestion-feedback.md
@@ -8,7 +8,7 @@
 
 ## Action
 
-Append entry to `.agents/daily-suggestion-log.md`:
+Append entry to `.claude/daily-suggestion-log.md`:
 
 ```markdown
 ## YYYY-MM-DD

--- a/.claude/commands/ds-daily-suggestion.md
+++ b/.claude/commands/ds-daily-suggestion.md
@@ -69,4 +69,4 @@ Return MR URL when complete.
 
 ## Feedback Integration
 
-When user runs `/ds-daily-suggestion-feedback`, outcomes are logged to `.agents/daily-suggestion-log.md`. Before suggesting, review this log for rejection patterns to avoid.
+When user runs `/ds-daily-suggestion-feedback`, outcomes are logged to `.claude/daily-suggestion-log.md`. Before suggesting, review this log for rejection patterns to avoid.

--- a/.claude/daily-suggestion-log.md
+++ b/.claude/daily-suggestion-log.md
@@ -1,0 +1,20 @@
+# Daily Suggestion Log
+
+## 2026-01-20 (attempt 1)
+- **Outcome**: rejected
+- **Reason**: Too trivial - single one-line change. Should generate 1-5 small commits to justify ~3-5 min review time.
+- **MR**: https://github.com/stancld/rossum-agents/pull/119
+
+## 2026-01-20 (attempt 2)
+- **Outcome**: accepted
+- **Note**: Vary suggestions across codebase areas (docs/code/commands etc.) across days to keep it interesting.
+- **MR**: https://github.com/stancld/rossum-agents/pull/120
+
+## 2026-01-20 (attempt 3)
+- **Outcome**: rejected
+- **Reason**: Too trivial (string replacements only). Never use "Co-Authored-By: Claude" in commits.
+- **MR**: https://github.com/stancld/rossum-agents/pull/121
+
+## 2026-01-20 (attempt 4)
+- **Outcome**: accepted
+- **MR**: https://github.com/stancld/rossum-agents/pull/122


### PR DESCRIPTION
## Summary
- Move `daily-suggestion-log.md` from `.agents/` (gitignored) to `.claude/` (tracked) to enable syncing across machines

## Review Notes
- Coffee-time review (~2 min)
- No behavioral changes