### PR TITLE
claude-commands: Add missing Output sections to ds-review and ds-roast

### DIFF
--- a/.claude/commands/ds-review.md
+++ b/.claude/commands/ds-review.md
@@ -27,6 +27,18 @@
 | Tests | If test files changed, ask whether to run `pytest` |
 | Summary | Generate short MR description of what was done |
 
+## Output
+
+Provide MR-ready summary:
+
+```
+## Summary
+- <1-2 bullets describing what was reviewed/changed>
+
+## Issues Found
+- <Critical issues addressed, or "None">
+```
+
 ## Constraints
 
 - Ask before running tests (use `AskUserQuestion`)

--- a/.claude/commands/ds-roast.md
+++ b/.claude/commands/ds-roast.md
@@ -39,6 +39,18 @@
 - Every criticism must include how to fix the mess
 - If something is actually good, say so (don't be a complete asshole)
 
+## Output
+
+End with verdict:
+
+```
+## Verdict
+
+**Rating**: <"Ship it", "Fix these things first", or "Burn it and start over">
+
+<1-2 sentence summary of whether this belongs in the codebase>
+```
+
 ## Constraints
 
 - No automatic commits


### PR DESCRIPTION
Continues the work from d30820d to ensure all commands have consistent Output sections.