### PR TITLE
docs: Fix incorrect directory paths in documentation

### DIFF
--- a/.claude/commands/ds-review-docs.md
+++ b/.claude/commands/ds-review-docs.md
@@ -24,8 +24,8 @@
 
 | Category | Check For |
 |----------|-----------|
-| MCP tools | New tools in `rossum_mcp/tools/` documented in README and `docs/source/mcp_reference.rst` |
-| Agent skills | New skills in `rossum_agent/skills/` documented in README and `docs/source/skills_and_subagents.rst` |
+| MCP tools | New tools in `rossum-mcp/rossum_mcp/tools/` documented in README and `docs/source/mcp_reference.rst` |
+| Agent skills | New skills in `rossum-agent/rossum_agent/skills/` documented in README and `docs/source/skills_and_subagents.rst` |
 | Changelogs | New features/fixes added to appropriate CHANGELOG.md |
 | API changes | Parameter changes, return type changes reflected in docs |
 | Examples | Code examples still valid after changes |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ When adding/modifying tools, update:
 
 | Tool Type | Files to Update |
 |-----------|-----------------|
-| MCP tools | `rossum_mcp/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
-| Agent tools | `rossum_agent/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
+| MCP tools | `rossum-mcp/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
+| Agent tools | `rossum-agent/README.md`, `docs/source/index.rst`, `docs/source/usage.rst` |
 
 Include: tool name, description, parameters with types, return format with JSON examples.
 


### PR DESCRIPTION
## Summary
- Fix directory paths using underscores to hyphens (`rossum_mcp/` → `rossum-mcp/`) in AGENTS.md and ds-review-docs.md

## Review Notes
- Coffee-time review (~3-5 min)
- Docs only

🤖 Generated with [Claude Code](https://claude.ai/code) daily suggestion