### PR TITLE
chore: Add missing environment variables to env.sample

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -1,13 +1,25 @@
-# When using AWS Bedrock Inference profile in a cluster
+# Required
+ROSSUM_API_BASE_URL=
+ROSSUM_API_TOKEN=
+
+# AWS Bedrock (for rossum-agent)
 AWS_BEDROCK_MODEL_ARN=
 AWS_BEDROCK_MODEL_ARN_SMALL=
 
+# Rossum Extensions
 API_TOKEN_OWNER=  # token owner used by rossum extensions
 SPLITTING_SCREEN_FLAG_NAME=
 SPLITTING_SCREEN_FLAG_VALUE=
 
-ROSSUM_API_BASE_URL=
-ROSSUM_API_TOKEN=
+# MCP Server
+ROSSUM_MCP_MODE=  # read-only or read-write (default: read-write)
+
+# Redis (for persistent storage)
+REDIS_HOST=
+REDIS_PORT=  # default: 6379
+
+# Streamlit app
+PUBLIC_URL=  # base URL for shareable chat links
 
 # Teleport JWT Authentication (user isolation auto-enabled when set)
-TELEPORT_JWT_JWKS_URL=  # URL to Teleport JWKS endpoint (e.g., https://teleport.example.com/.well-known/jwks.json)
+TELEPORT_JWT_JWKS_URL=  # URL to Teleport JWKS endpoint


### PR DESCRIPTION
## Summary
- Sync `env.sample` with documented environment variables from `CLAUDE.md`
- Add missing variables: `ROSSUM_MCP_MODE`, `REDIS_HOST`, `REDIS_PORT`, `PUBLIC_URL`
- Reorganize into logical groups with section comments for clarity

## Review Notes
- Coffee-time review (~3-5 min)
- Docs sync only, no behavioral changes

🤖 Generated with [Claude Code](https://claude.ai/code) daily suggestion