### PR TITLE
rossum-agent: Remove features enabled tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 
 ## Architecture
 
-- **rossum-mcp**: FastMCP server in `rossum_mcp/server.py`; tools registered from `rossum_mcp/tools/` modules, 43 tools
+- **rossum-mcp**: FastMCP server in `rossum_mcp/server.py`; tools registered from `rossum_mcp/tools/` modules, 41 tools
 - **rossum-agent**: AI agent with prompts in `rossum_agent/prompts/`, skills in `rossum_agent/skills/`
 - **rossum-agent-tui**: Development test-bed TUI for rossum-agent. Not production code — no tests required.
 - **New skills**: Add to `rossum_agent/prompts/base_prompt.py` ROSSUM_EXPERT_INTRO section

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/stancld/rossum-agents/badge)](https://www.codefactor.io/repository/github/stancld/rossum-agents)
 
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io/)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-43-blue.svg)](#available-tools)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-41-blue.svg)](#available-tools)
 [![Rossum API](https://img.shields.io/badge/Rossum-API-orange.svg)](https://github.com/rossumai/rossum-api)
 [![Claude Opus 4.6](https://img.shields.io/badge/Claude-Opus_4.6-blueviolet.svg)](https://www.anthropic.com/claude/opus)
 
@@ -299,7 +299,7 @@ See the [full documentation](https://stancld.github.io/rossum-agents/skills_and_
 
 ## MCP Tools
 
-The MCP server provides **43 tools** organized into categories:
+The MCP server provides **41 tools** organized into categories:
 
 | Category | Tools | Description |
 |----------|-------|-------------|

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ This project enables three progressive levels of AI-powered Rossum orchestration
 Features
 --------
 
-The MCP server provides **43 tools** organized into categories:
+The MCP server provides **41 tools** organized into categories:
 
 **Unified Read Layer**
 
@@ -82,11 +82,6 @@ The MCP server provides **43 tools** organized into categories:
 
 * **create_workspace** - Create a new workspace
 * **delete_workspace** - Delete a workspace
-
-**Organization Groups**
-
-* **are_lookup_fields_enabled** - Check if lookup fields are enabled for an organization group
-* **are_reasoning_fields_enabled** - Check if reasoning fields are enabled for an organization group
 
 **User Management**
 

--- a/docs/source/mcp_reference.rst
+++ b/docs/source/mcp_reference.rst
@@ -587,40 +587,6 @@ prune_schema_fields
   Removes multiple fields from a schema at once, keeping only specified fields and their
   ancestor sections/multivalues. Efficient for pruning unwanted fields during setup.
 
-are_lookup_fields_enabled
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-**MCP Tool:**
-  ``are_lookup_fields_enabled()``
-
-**API Endpoint:**
-  ``GET /v1/organization_groups``
-
-**Returns:**
-  ``{"enabled": bool}``
-
-**Implementation:**
-  Returns ``{"enabled": True}`` if any organization group has both ``datasets`` and
-  ``lookup_fields`` features set to ``{"enabled": True}`` in its ``features`` dict.
-  Returns ``{"enabled": False}`` otherwise.
-
-are_reasoning_fields_enabled
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-**MCP Tool:**
-  ``are_reasoning_fields_enabled()``
-
-**API Endpoint:**
-  ``GET /v1/organization_groups``
-
-**Returns:**
-  ``{"enabled": bool}``
-
-**Implementation:**
-  Returns ``{"enabled": True}`` if any organization group has the ``reasoning_fields``
-  feature set to ``{"enabled": True}`` in its ``features`` dict. Returns
-  ``{"enabled": False}`` otherwise.
-
 list_tool_categories
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -684,10 +650,6 @@ list_tool_categories
    * - ``workspaces``
      - Workspace management: organize queues
      - workspace, organization
-   * - ``organization_groups``
-     - Organization group management: view license groups
-     - organization group, license, trial, production, deployment
-
 **Example:**
 
 .. code-block:: python

--- a/regression_tests/custom_checks/multi_turn_schema_revert.py
+++ b/regression_tests/custom_checks/multi_turn_schema_revert.py
@@ -16,15 +16,11 @@ def check_multi_turn_schema_reverted(steps: list[AgentStep], api_base_url: str, 
 
     Checks:
     - revert_commit was called
-    - are_reasoning_fields_enabled was called (agent verified feature availability)
     - Session-added fields (the_net_terms, recipient_country) are gone from the schema
     - Schema still has the original EU template fields (>= 5 datapoints)
     """
     if not agent_called_tool(steps, "restore_entity_version"):
         return False, "Agent never called restore_entity_version"
-
-    if not agent_called_tool(steps, "are_reasoning_fields_enabled"):
-        return False, "Agent never checked reasoning field availability (are_reasoning_fields_enabled not called)"
 
     schema_id = _extract_schema_id_from_steps(steps)
     if not schema_id:

--- a/regression_tests/test_cases.py
+++ b/regression_tests/test_cases.py
@@ -701,7 +701,6 @@ REGRESSION_TEST_CASES: list[RegressionTestCase] = [
                 "create_queue_from_template",
                 "suggest_formula_field",
                 ("patch_schema", "patch_schema_with_subagent"),
-                "are_reasoning_fields_enabled",
                 "load_skill",
                 "restore_entity_version",
             ],

--- a/rossum-mcp/CHANGELOG.md
+++ b/rossum-mcp/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - Added `get` tool: fetch any entity by ID with a single unified tool — supports `queue`, `schema`, `hook`, `engine`, `rule`, `user`, `workspace`, `email_template`, `organization_group`, `organization_limit`, `annotation`, `relation`, `document_relation`; `include_related=True` enriches with linked data (queue→schema_tree+engine+hooks, schema→queues+rules, hook→queues+events) [#221](https://github.com/stancld/rossum-agents/pull/221)
 - Added `search` tool: list/filter any entity with typed, entity-specific query objects — covers all `get`-supported types plus search-only entities `hook_log`, `hook_template`, `user_role` [#221](https://github.com/stancld/rossum-agents/pull/221)
 
+### Removed
+- Removed `are_lookup_fields_enabled` and `are_reasoning_fields_enabled` tools — feature availability is inferred by the agent from organization group data via the `get` / `search` tools
+
 ### Changed
 - `update_queue` parameter `queue_data` is now a typed `QueueUpdateData` schema instead of an untyped dict — LLMs see valid field names and types directly in the JSON schema [#221](https://github.com/stancld/rossum-agents/pull/221)
 - `update_engine` parameter `engine_data` is now a typed `EngineUpdateData` schema instead of an untyped dict [#221](https://github.com/stancld/rossum-agents/pull/221)

--- a/rossum-mcp/README.md
+++ b/rossum-mcp/README.md
@@ -2,14 +2,14 @@
 
 <div align="center">
 
-**MCP server for AI-powered Rossum document processing. 43 tools for queues, schemas, hooks, engines, and more.**
+**MCP server for AI-powered Rossum document processing. 41 tools for queues, schemas, hooks, engines, and more.**
 
 [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://stancld.github.io/rossum-agents/)
 [![Python](https://img.shields.io/pypi/pyversions/rossum-mcp.svg)](https://pypi.org/project/rossum-mcp/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PyPI - rossum-mcp](https://img.shields.io/pypi/v/rossum-mcp?label=rossum-mcp)](https://pypi.org/project/rossum-mcp/)
 [![Coverage](https://codecov.io/gh/stancld/rossum-agents/branch/master/graph/badge.svg?flag=rossum-mcp)](https://codecov.io/gh/stancld/rossum-agents)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-43-blue.svg)](#available-tools)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-41-blue.svg)](#available-tools)
 
 [![Rossum API](https://img.shields.io/badge/Rossum-API-orange.svg)](https://github.com/rossumai/rossum-api)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io/)
@@ -97,7 +97,7 @@ Assistant: [calls set_mcp_mode("read-write")] → Mode switched to read-write
 
 ## Available Tools
 
-The server provides **43 tools** organized into categories:
+The server provides **41 tools** organized into categories:
 
 | Category | Tools | Description |
 |----------|-------|-------------|
@@ -145,9 +145,6 @@ Supported entities for `search` (with typed filters): all `get` entities plus `h
 
 **Workspace Management:**
 `create_workspace`, `delete_workspace`
-
-**Organization Groups:**
-`are_lookup_fields_enabled`, `are_reasoning_fields_enabled`
 
 **User Management:**
 `create_user`, `update_user`

--- a/rossum-mcp/TOOLS.md
+++ b/rossum-mcp/TOOLS.md
@@ -1,6 +1,6 @@
 # Rossum MCP Tools Reference
 
-Complete API reference for all 43 MCP tools. For quick start and setup, see [README.md](README.md).
+Complete API reference for all 41 MCP tools. For quick start and setup, see [README.md](README.md).
 
 ---
 
@@ -612,28 +612,6 @@ Deletes a workspace by ID. Fails if the workspace still contains queues.
 
 ---
 
-## Organization Groups (2 tools)
-
-### are_lookup_fields_enabled
-
-Checks whether lookup fields are available. Both `datasets` and `lookup_fields` features must be enabled in at least one organization group.
-
-**Returns:**
-```json
-{"enabled": true}
-```
-
-### are_reasoning_fields_enabled
-
-Checks whether reasoning fields are available. The `reasoning_fields` feature must be enabled in at least one organization group.
-
-**Returns:**
-```json
-{"enabled": true}
-```
-
----
-
 ## User Management (2 tools)
 
 ### create_user
@@ -725,7 +703,7 @@ Set the MCP operation mode. Use `read-only` to disable write operations, `read-w
 
 Lists all available tool categories with descriptions, tool names, read/write status, and keywords for dynamic tool loading.
 
-**Available categories:** `read`, `annotations`, `queues`, `schemas`, `engines`, `hooks`, `email_templates`, `rules`, `organization_groups`, `users`, `workspaces`
+**Available categories:** `read`, `annotations`, `queues`, `schemas`, `engines`, `hooks`, `email_templates`, `rules`, `users`, `workspaces`
 
 ---
 

--- a/rossum-mcp/rossum_mcp/server.py
+++ b/rossum-mcp/rossum_mcp/server.py
@@ -16,7 +16,6 @@ from rossum_mcp.tools import (
     register_email_template_tools,
     register_engine_tools,
     register_hook_tools,
-    register_organization_group_tools,
     register_queue_tools,
     register_read_tools,
     register_rule_tools,
@@ -59,7 +58,6 @@ def create_app() -> FastMCP:
     register_schema_tools(mcp, client)
     register_engine_tools(mcp, client)
     register_hook_tools(mcp, client)
-    register_organization_group_tools(mcp, client)
     register_email_template_tools(mcp, client)
     register_rule_tools(mcp, client)
     register_user_tools(mcp, client)

--- a/rossum-mcp/rossum_mcp/tools/__init__.py
+++ b/rossum-mcp/rossum_mcp/tools/__init__.py
@@ -12,7 +12,6 @@ from rossum_mcp.tools.discovery import register_discovery_tools
 from rossum_mcp.tools.email_templates import register_email_template_tools
 from rossum_mcp.tools.engines import register_engine_tools
 from rossum_mcp.tools.hooks import register_hook_tools
-from rossum_mcp.tools.organization_groups import register_organization_group_tools
 from rossum_mcp.tools.queues import register_queue_tools
 from rossum_mcp.tools.read_layer import register_read_tools
 from rossum_mcp.tools.rules import register_rule_tools
@@ -29,7 +28,6 @@ __all__ = [
     "register_email_template_tools",
     "register_engine_tools",
     "register_hook_tools",
-    "register_organization_group_tools",
     "register_queue_tools",
     "register_read_tools",
     "register_rule_tools",

--- a/rossum-mcp/rossum_mcp/tools/catalog.py
+++ b/rossum-mcp/rossum_mcp/tools/catalog.py
@@ -52,19 +52,6 @@ CATEGORY_META: dict[str, CategoryMeta] = {
         description="Validation rules: manage schema validation rules",
         keywords=["rule", "validation", "constraint"],
     ),
-    "organization_groups": CategoryMeta(
-        description="Organization group management: view license groups shared across organizations",
-        keywords=[
-            "organization group",
-            "license",
-            "trial",
-            "production",
-            "deployment",
-            "lookup fields",
-            "datasets",
-            "reasoning fields",
-        ],
-    ),
     "users": CategoryMeta(
         description="User management: create, update, list users and roles",
         keywords=["user", "role", "permission", "token_owner"],

--- a/rossum-mcp/rossum_mcp/tools/organization_groups.py
+++ b/rossum-mcp/rossum_mcp/tools/organization_groups.py
@@ -9,7 +9,6 @@ from rossum_api.models.organization_group import OrganizationGroup
 from rossum_mcp.tools.base import build_filters, filter_by_name_regex, graceful_list
 
 if TYPE_CHECKING:
-    from fastmcp import FastMCP
     from rossum_api import AsyncRossumAPIClient
 
 logger = logging.getLogger(__name__)
@@ -27,43 +26,3 @@ async def _list_organization_groups(
     filters = build_filters(name=None if use_regex else name)
     items = (await graceful_list(client, Resource.OrganizationGroup, "organization_group", **filters)).items
     return filter_by_name_regex(items, name, use_regex)
-
-
-def _is_feature_enabled(features: dict, key: str) -> bool:
-    return bool(features.get(key, {}).get("enabled"))
-
-
-async def _are_lookup_fields_enabled(client: AsyncRossumAPIClient) -> dict:
-    groups = await _list_organization_groups(client)
-    for group in groups:
-        features = group.features or {}
-        if _is_feature_enabled(features, "datasets") and _is_feature_enabled(features, "lookup_fields"):
-            return {"enabled": True}
-    return {"enabled": False}
-
-
-async def _are_reasoning_fields_enabled(client: AsyncRossumAPIClient) -> dict:
-    groups = await _list_organization_groups(client)
-    for group in groups:
-        features = group.features or {}
-        if _is_feature_enabled(features, "reasoning_fields"):
-            return {"enabled": True}
-    return {"enabled": False}
-
-
-def register_organization_group_tools(mcp: FastMCP, client: AsyncRossumAPIClient) -> None:
-    @mcp.tool(
-        description="Check if lookup fields are enabled. Both 'datasets' and 'lookup_fields' features must be enabled in an organization group.",
-        tags={"organization_groups"},
-        annotations={"readOnlyHint": True},
-    )
-    async def are_lookup_fields_enabled() -> dict:
-        return await _are_lookup_fields_enabled(client)
-
-    @mcp.tool(
-        description="Check if reasoning fields are enabled. The 'reasoning_fields' feature must be enabled in an organization group.",
-        tags={"organization_groups"},
-        annotations={"readOnlyHint": True},
-    )
-    async def are_reasoning_fields_enabled() -> dict:
-        return await _are_reasoning_fields_enabled(client)

--- a/rossum-mcp/tests/test_catalog.py
+++ b/rossum-mcp/tests/test_catalog.py
@@ -21,7 +21,6 @@ class TestCategoryMeta:
             "hooks",
             "email_templates",
             "rules",
-            "organization_groups",
             "users",
             "workspaces",
         }

--- a/rossum-mcp/tests/tools/test_organization_groups.py
+++ b/rossum-mcp/tests/tools/test_organization_groups.py
@@ -10,7 +10,6 @@ from rossum_mcp.tools.organization_groups import _get_organization_group, _list_
 
 
 def create_mock_organization_group(**kwargs) -> OrganizationGroup:
-    """Create a mock OrganizationGroup dataclass instance with default values."""
     defaults = {
         "id": 1,
         "name": "Test Organization Group",
@@ -28,29 +27,10 @@ def create_mock_organization_group(**kwargs) -> OrganizationGroup:
 
 @pytest.fixture
 def mock_client() -> AsyncMock:
-    """Create a mock AsyncRossumAPIClient."""
     client = AsyncMock()
     client._http_client = AsyncMock()
     client._deserializer = Mock(side_effect=lambda resource, raw: raw)
     return client
-
-
-@pytest.fixture
-def mock_mcp() -> Mock:
-    """Create a mock FastMCP instance that captures registered tools."""
-    tools: dict = {}
-
-    def tool_decorator(**kwargs):
-        def wrapper(fn):
-            tools[fn.__name__] = fn
-            return fn
-
-        return wrapper
-
-    mcp = Mock()
-    mcp.tool = tool_decorator
-    mcp._tools = tools
-    return mcp
 
 
 @pytest.mark.unit
@@ -172,140 +152,3 @@ class TestListOrganizationGroups:
         result = await _list_organization_groups(mock_client, name="^acme$", use_regex=True)
 
         assert len(result) == 0
-
-
-@pytest.mark.unit
-class TestAreLookupFieldsEnabled:
-    """Tests for are_lookup_fields_enabled tool."""
-
-    @pytest.mark.asyncio
-    async def test_returns_enabled_when_both_features_set(self, mock_mcp: Mock, mock_client: AsyncMock) -> None:
-        from rossum_mcp.tools.organization_groups import register_organization_group_tools
-
-        register_organization_group_tools(mock_mcp, mock_client)
-
-        mock_og = create_mock_organization_group(
-            features={"datasets": {"enabled": True}, "lookup_fields": {"enabled": True}}
-        )
-
-        async def mock_fetch_all(resource, **filters):
-            yield mock_og
-
-        mock_client._http_client.fetch_all = mock_fetch_all
-
-        are_lookup_fields_enabled = mock_mcp._tools["are_lookup_fields_enabled"]
-        result = await are_lookup_fields_enabled()
-
-        assert result == {"enabled": True}
-
-    @pytest.mark.asyncio
-    async def test_returns_disabled_when_lookup_fields_missing(self, mock_mcp: Mock, mock_client: AsyncMock) -> None:
-        from rossum_mcp.tools.organization_groups import register_organization_group_tools
-
-        register_organization_group_tools(mock_mcp, mock_client)
-
-        mock_og = create_mock_organization_group(features={"datasets": {"enabled": True}})
-
-        async def mock_fetch_all(resource, **filters):
-            yield mock_og
-
-        mock_client._http_client.fetch_all = mock_fetch_all
-
-        are_lookup_fields_enabled = mock_mcp._tools["are_lookup_fields_enabled"]
-        result = await are_lookup_fields_enabled()
-
-        assert result == {"enabled": False}
-
-    @pytest.mark.asyncio
-    async def test_returns_disabled_when_features_none(self, mock_mcp: Mock, mock_client: AsyncMock) -> None:
-        from rossum_mcp.tools.organization_groups import register_organization_group_tools
-
-        register_organization_group_tools(mock_mcp, mock_client)
-
-        mock_og = create_mock_organization_group(features=None)
-
-        async def mock_fetch_all(resource, **filters):
-            yield mock_og
-
-        mock_client._http_client.fetch_all = mock_fetch_all
-
-        are_lookup_fields_enabled = mock_mcp._tools["are_lookup_fields_enabled"]
-        result = await are_lookup_fields_enabled()
-
-        assert result == {"enabled": False}
-
-    @pytest.mark.asyncio
-    async def test_returns_disabled_when_no_groups(self, mock_mcp: Mock, mock_client: AsyncMock) -> None:
-        from rossum_mcp.tools.organization_groups import register_organization_group_tools
-
-        register_organization_group_tools(mock_mcp, mock_client)
-
-        async def mock_fetch_all(resource, **filters):
-            return
-            yield  # make it an async generator
-
-        mock_client._http_client.fetch_all = mock_fetch_all
-
-        are_lookup_fields_enabled = mock_mcp._tools["are_lookup_fields_enabled"]
-        result = await are_lookup_fields_enabled()
-
-        assert result == {"enabled": False}
-
-
-@pytest.mark.unit
-class TestAreReasoningFieldsEnabled:
-    """Tests for are_reasoning_fields_enabled tool."""
-
-    @pytest.mark.asyncio
-    async def test_returns_enabled_when_feature_set(self, mock_mcp: Mock, mock_client: AsyncMock) -> None:
-        from rossum_mcp.tools.organization_groups import register_organization_group_tools
-
-        register_organization_group_tools(mock_mcp, mock_client)
-
-        mock_og = create_mock_organization_group(features={"reasoning_fields": {"enabled": True}})
-
-        async def mock_fetch_all(resource, **filters):
-            yield mock_og
-
-        mock_client._http_client.fetch_all = mock_fetch_all
-
-        are_reasoning_fields_enabled = mock_mcp._tools["are_reasoning_fields_enabled"]
-        result = await are_reasoning_fields_enabled()
-
-        assert result == {"enabled": True}
-
-    @pytest.mark.asyncio
-    async def test_returns_disabled_when_feature_missing(self, mock_mcp: Mock, mock_client: AsyncMock) -> None:
-        from rossum_mcp.tools.organization_groups import register_organization_group_tools
-
-        register_organization_group_tools(mock_mcp, mock_client)
-
-        mock_og = create_mock_organization_group(features={})
-
-        async def mock_fetch_all(resource, **filters):
-            yield mock_og
-
-        mock_client._http_client.fetch_all = mock_fetch_all
-
-        are_reasoning_fields_enabled = mock_mcp._tools["are_reasoning_fields_enabled"]
-        result = await are_reasoning_fields_enabled()
-
-        assert result == {"enabled": False}
-
-    @pytest.mark.asyncio
-    async def test_returns_disabled_when_features_none(self, mock_mcp: Mock, mock_client: AsyncMock) -> None:
-        from rossum_mcp.tools.organization_groups import register_organization_group_tools
-
-        register_organization_group_tools(mock_mcp, mock_client)
-
-        mock_og = create_mock_organization_group(features=None)
-
-        async def mock_fetch_all(resource, **filters):
-            yield mock_og
-
-        mock_client._http_client.fetch_all = mock_fetch_all
-
-        are_reasoning_fields_enabled = mock_mcp._tools["are_reasoning_fields_enabled"]
-        result = await are_reasoning_fields_enabled()
-
-        assert result == {"enabled": False}


### PR DESCRIPTION
Remove features enabled tools, since agent simply can use search organization limits.