### PR TITLE
fix: update GitHub Actions versions in update-knowledge-base workflow

### DIFF
--- a/.github/workflows/update-knowledge-base.yaml
+++ b/.github/workflows/update-knowledge-base.yaml
@@ -14,11 +14,11 @@ jobs:
   update-kb:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -113,7 +113,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: automated/update-knowledge-base
           delete-branch: true


### PR DESCRIPTION
Bump actions to Node.js 22+ compatible versions to resolve Node.js 20
deprecation warnings and update create-pull-request to v8:
- actions/checkout v4 → v6
- actions/setup-python v5 → v6
- peter-evans/create-pull-request v7 → v8

https://claude.ai/code/session_01EGKB7LjM6tnqPwHJ1gVFMo