### PR TITLE
rossum-agent: Migrate package loggers to structlog and instrument tool calls

### DIFF
--- a/regression_tests/conftest.py
+++ b/regression_tests/conftest.py
@@ -21,6 +21,11 @@ from rossum_agent.tools.core import AgentContext, reset_context, set_context
 from rossum_agent.tools.dynamic_tools import get_write_tools_async
 from rossum_agent.tools.task_tracker import TaskTracker
 from rossum_agent.url_context import extract_url_context, format_context_for_prompt
+from rossum_mcp.logging_config import LogFormat, LogLevel, setup_logging
+
+# Route structlog and stdlib loggers through the shared setup so regression test
+# output uses the same ISO timestamps and contextvars as production.
+setup_logging(log_level=LogLevel.INFO, log_format=LogFormat.CONSOLE)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable

--- a/rossum-agent/CHANGELOG.md
+++ b/rossum-agent/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `VALKEY_PASSWORD` environment variable for authenticated Valkey connections [#356](https://github.com/stancld/rossum-agents/pull/356)
 - Structured logging via `structlog` (reusing `rossum_mcp.logging_config`); configurable with `ROSSUM_AGENT_LOG_LEVEL` and `ROSSUM_AGENT_LOG_FORMAT` environment variables [#373](https://github.com/stancld/rossum-agents/pull/373)
+- Migrate all `rossum_agent` module loggers from stdlib `logging.getLogger` to `structlog.get_logger` so package log records render via structlog processors [#375](https://github.com/stancld/rossum-agents/pull/375)
+- Emit structured `tool_call.completed` / `tool_call.failed` events with `tool_name`, `duration_seconds`, `status` (and `error_type` on failure) for each tool invocation, mirroring the `rossum_mcp.middleware` observability format [#375](https://github.com/stancld/rossum-agents/pull/375)
 
 ### Fixed
 - Prevent leaking internal error details to clients — error SSE events now return a generic message instead of the raw exception string [#355](https://github.com/stancld/rossum-agents/pull/355)

--- a/rossum-agent/rossum_agent/agent/cautious_gate.py
+++ b/rossum-agent/rossum_agent/agent/cautious_gate.py
@@ -7,8 +7,9 @@ For update operations on identifiable entities, a field-level diff is shown inst
 from __future__ import annotations
 
 import json
-import logging
 from typing import TYPE_CHECKING
+
+import structlog
 
 from rossum_agent.agent.models import ToolCall, ToolResult
 from rossum_agent.api.models.schemas import Persona
@@ -28,7 +29,7 @@ from rossum_agent.utils import compute_json_diff
 if TYPE_CHECKING:
     from rossum_agent.rossum_mcp_integration.connection import MCPConnection
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def is_write_tool(name: str) -> bool:

--- a/rossum-agent/rossum_agent/agent/core.py
+++ b/rossum-agent/rossum_agent/agent/core.py
@@ -41,13 +41,13 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-import logging
 import random
 import time
 from contextvars import copy_context
 from functools import partial
 from typing import TYPE_CHECKING, Literal
 
+import structlog
 from anthropic import APIError, APITimeoutError, RateLimitError
 from anthropic._types import Omit
 
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
     from rossum_agent.agent.types import UserContent
     from rossum_agent.rossum_mcp_integration.connection import MCPConnection
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 EFFORT: Literal["max", "high", "medium", "low"] = "high"
 MAX_OUTPUT_TOKENS = 128000  # Opus 4.6 limit

--- a/rossum-agent/rossum_agent/agent/skills.py
+++ b/rossum-agent/rossum_agent/agent/skills.py
@@ -7,12 +7,13 @@ after the closing ``---`` is the skill content delivered to the agent.
 
 from __future__ import annotations
 
-import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 # Default skills directory path relative to rossum_agent package
 _SKILLS_DIR = Path(__file__).parent.parent / "skills"

--- a/rossum-agent/rossum_agent/agent/spillover.py
+++ b/rossum-agent/rossum_agent/agent/spillover.py
@@ -8,14 +8,15 @@ The agent can then use run_jq or run_grep to query the full content.
 from __future__ import annotations
 
 import json
-import logging
 import re
 from typing import TYPE_CHECKING
+
+import structlog
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 SPILLOVER_THRESHOLD = 30_000
 _PREVIEW_ITEMS = 3

--- a/rossum-agent/rossum_agent/agent/streaming.py
+++ b/rossum-agent/rossum_agent/agent/streaming.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import json
-import logging
 import time
 from typing import TYPE_CHECKING
 
+import structlog
 from anthropic.types import (
     ContentBlockStopEvent,
     InputJSONDelta,
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
     from anthropic.types import Message, MessageStreamEvent
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Buffer text tokens for this duration before first flush to allow time to determine
 # whether this is an intermediate step (with tool calls) or final answer text.

--- a/rossum-agent/rossum_agent/agent/tool_execution.py
+++ b/rossum-agent/rossum_agent/agent/tool_execution.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import json
-import logging
 import queue
+import time
 from contextvars import copy_context
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
+import structlog
 from pydantic import BaseModel
 
 from rossum_agent.agent.cautious_gate import check_cautious_write_gate
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
     from rossum_agent.agent.memory import AgentMemory
     from rossum_agent.rossum_mcp_integration.connection import MCPConnection
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 MAX_TOOL_OUTPUT_LENGTH = 30000
 
@@ -154,8 +155,9 @@ async def execute_tool_with_progress(
     def token_callback(usage: SubAgentTokenUsage) -> None:
         token_queue.put(usage)
 
-    logger.info("Tool call: %s(%s)", tool_call.name, tool_call.arguments)
+    logger.info("tool_call.started", tool_name=tool_call.name, arguments=tool_call.arguments)
 
+    start = time.perf_counter()
     try:
         if tool_call.name in get_internal_tool_names():
             logger.info(f"Calling internal tool {tool_call.name}")
@@ -190,13 +192,27 @@ async def execute_tool_with_progress(
             result = await mcp_connection.call_tool(tool_call.name, tool_call.arguments)
             content = serialize_tool_result(result)
 
+        logger.info(
+            "tool_call.completed",
+            tool_name=tool_call.name,
+            duration_seconds=round(time.perf_counter() - start, 3),
+            status="success",
+        )
+
         content = maybe_spill(content, tool_call.name, step_num, get_context().get_output_dir(), tool_call.id)
         content = truncate_content(content)
         yield ToolResult(tool_call_id=tool_call.id, name=tool_call.name, content=content)
 
     except Exception as e:
         error_msg = f"Tool {tool_call.name} failed: {e}"
-        logger.warning(f"Tool {tool_call.name} failed: {e}", exc_info=True)
+        logger.warning(
+            "tool_call.failed",
+            tool_name=tool_call.name,
+            duration_seconds=round(time.perf_counter() - start, 3),
+            status="error",
+            error_type=type(e).__name__,
+            exc_info=True,
+        )
         yield ToolResult(tool_call_id=tool_call.id, name=tool_call.name, content=error_msg, is_error=True)
 
 

--- a/rossum-agent/rossum_agent/api/dependencies.py
+++ b/rossum-agent/rossum_agent/api/dependencies.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 from dataclasses import dataclass
@@ -11,6 +10,7 @@ from typing import Annotated
 from urllib.parse import urlparse
 
 import httpx
+import structlog
 from fastapi import Header, HTTPException, Request, status
 
 from rossum_agent.api.services.agent_service import AgentService
@@ -18,7 +18,7 @@ from rossum_agent.api.services.chat_service import ChatService
 from rossum_agent.api.services.file_service import FileService
 from rossum_agent.valkey_client import ValkeyConnection
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Base allowed hosts pattern
 _BASE_ALLOWED_HOSTS = r"elis\.rossum\.ai|api\.elis\.rossum\.ai|(.*\.)?api\.rossum\.ai|.*\.rossum\.(app|ai)|(elis|api\.elis)\.develop\.r8\.lol"

--- a/rossum-agent/rossum_agent/api/main.py
+++ b/rossum-agent/rossum_agent/api/main.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import logging
 import os
 import signal
 import sys
@@ -12,6 +11,7 @@ import threading
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+import structlog
 import uvicorn
 from fastapi import FastAPI, Request, status
 from gunicorn.app.base import BaseApplication
@@ -40,7 +40,7 @@ from rossum_agent.api.shutdown import shutdown_state
 from rossum_agent.postgres_storage import PostgresStorage
 from rossum_agent.valkey_client import ValkeyConnection
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 MAX_REQUEST_SIZE = 10 * 1024 * 1024  # 10 MB (supports image uploads)
 

--- a/rossum-agent/rossum_agent/api/routes/helpers.py
+++ b/rossum-agent/rossum_agent/api/routes/helpers.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import contextvars
-import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+import structlog
 from anthropic.types import TextBlock
 
 from rossum_agent.agent.memory import AgentMemory
@@ -25,7 +25,7 @@ from rossum_agent.valkey_client import ValkeyConnection
 if TYPE_CHECKING:
     from rossum_agent.api.services.agent_service import StreamEvent
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 SSE_KEEPALIVE_INTERVAL = 15
 SSE_KEEPALIVE_COMMENT = ": keepalive\n\n"

--- a/rossum-agent/rossum_agent/api/routes/messages.py
+++ b/rossum-agent/rossum_agent/api/routes/messages.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from slowapi import Limiter
@@ -79,7 +79,7 @@ RESPONSE_HEADERS = {
     "x-vercel-ai-ui-message-stream": "v1",
 }
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 limiter = Limiter(key_func=get_remote_address)
 

--- a/rossum-agent/rossum_agent/api/routes/slack.py
+++ b/rossum-agent/rossum_agent/api/routes/slack.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import logging
 import os
 from dataclasses import dataclass
 from typing import Annotated
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from rossum_api import APIClientError, AsyncRossumAPIClient
 from rossum_api.dtos import Token
@@ -17,7 +17,7 @@ from rossum_agent.api.services.chat_service import ChatService
 from rossum_agent.api.services.slack_service import SlackService, SlackServiceError
 from rossum_agent.url_context import extract_url_context
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 limiter = Limiter(key_func=get_remote_address)
 

--- a/rossum-agent/rossum_agent/api/routes/stream_adapter.py
+++ b/rossum-agent/rossum_agent/api/routes/stream_adapter.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
+
+import structlog
 
 from rossum_agent.agent.models import (
     AgentQuestionPart,
@@ -20,7 +21,7 @@ from rossum_agent.agent.models import (
 from rossum_agent.api.services.agent_service import StreamEvent
 from rossum_agent.mermaid_sanitizer import sanitize_mermaid_in_markdown
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass

--- a/rossum-agent/rossum_agent/api/services/agent_service.py
+++ b/rossum-agent/rossum_agent/api/services/agent_service.py
@@ -7,10 +7,11 @@ import base64
 import contextlib
 import contextvars
 import dataclasses
-import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+import structlog
 
 from rossum_agent.agent.core import RossumAgent, create_agent
 from rossum_agent.agent.memory import AgentMemory
@@ -63,7 +64,7 @@ if TYPE_CHECKING:
     from rossum_agent.agent.types import UserContent
     from rossum_agent.change_tracking.models import ConfigCommit
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _FILE_CONTENT_OPEN_TAG = '<file_content path="'
 _FILE_CONTENT_CLOSE_TAG = "\n</file_content>"

--- a/rossum-agent/rossum_agent/api/services/chat_service.py
+++ b/rossum-agent/rossum_agent/api/services/chat_service.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import datetime as dt
-import logging
 import secrets
 from typing import TYPE_CHECKING
+
+import structlog
 
 from rossum_agent.api.models.schemas import (
     ChatDetail,
@@ -72,7 +73,7 @@ if TYPE_CHECKING:
 
     from rossum_agent.postgres_storage import PostgresStorage
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class ChatService:

--- a/rossum-agent/rossum_agent/api/services/slack_service.py
+++ b/rossum-agent/rossum_agent/api/services/slack_service.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-import logging
+
+import structlog
 
 try:
     from slack_sdk.errors import SlackApiError
@@ -10,7 +11,7 @@ except ImportError:
     AsyncWebClient = None  # ty:ignore[invalid-assignment]
     SlackApiError = None  # ty:ignore[invalid-assignment]
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class SlackServiceError(Exception):

--- a/rossum-agent/rossum_agent/change_tracking/commit_service.py
+++ b/rossum-agent/rossum_agent/change_tracking/commit_service.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
+
+import structlog
 
 from rossum_agent.bedrock_client import create_bedrock_client, get_small_model_id
 from rossum_agent.change_tracking.models import ConfigCommit, compute_commit_hash
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 _EPOCH = datetime.min.replace(tzinfo=UTC)
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _format_changes_for_message(changes: list[EntityChange]) -> str:

--- a/rossum-agent/rossum_agent/change_tracking/store.py
+++ b/rossum-agent/rossum_agent/change_tracking/store.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import TYPE_CHECKING, cast
+
+import structlog
 
 from rossum_agent.change_tracking.models import ConfigCommit
 
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
 
     import valkey
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Default TTL for commit data (30 days, matching chat TTL)
 DEFAULT_COMMIT_TTL_SECONDS = 30 * 24 * 3600

--- a/rossum-agent/rossum_agent/postgres_storage.py
+++ b/rossum-agent/rossum_agent/postgres_storage.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import datetime as dt
 import functools
-import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast
 
 import sqlalchemy as sa
+import structlog
 from alembic import command
 from alembic.config import Config
 from sqlalchemy.dialects.postgresql import BYTEA, JSONB, insert
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.engine import Engine
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/rossum-agent/rossum_agent/rossum_mcp_integration/change_tracking.py
+++ b/rossum-agent/rossum_agent/rossum_mcp_integration/change_tracking.py
@@ -7,8 +7,9 @@ for version control.
 from __future__ import annotations
 
 import json
-import logging
 from typing import TYPE_CHECKING, Any, cast
+
+import structlog
 
 from rossum_agent.change_tracking.commit_service import CommitService
 from rossum_agent.change_tracking.models import EntityChange
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
     from rossum_agent.change_tracking.store import CommitStore, SnapshotStore
     from rossum_agent.rossum_mcp_integration.connection import MCPConnection
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class ChangeTrackingMixin:

--- a/rossum-agent/rossum_agent/rossum_mcp_integration/connection.py
+++ b/rossum-agent/rossum_agent/rossum_mcp_integration/connection.py
@@ -6,12 +6,12 @@ and the connect_mcp_server context manager.
 
 from __future__ import annotations
 
-import logging
 import os
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import structlog
 from fastmcp import Client
 from fastmcp.client.transports import StdioTransport
 
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from rossum_agent.change_tracking.models import EntityChange
     from rossum_agent.change_tracking.store import CommitStore, SnapshotStore
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass

--- a/rossum-agent/rossum_agent/tools/change_history.py
+++ b/rossum-agent/rossum_agent/tools/change_history.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import random
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+import structlog
 from anthropic import beta_tool
 from rossum_api import APIClientError, AsyncRossumAPIClient
 from rossum_api.domain_logic.resources import Resource
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from rossum_agent.change_tracking.store import CommitStore, SnapshotStore
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Entity types that can be reverted programmatically via rossum_api
 _ENTITY_TYPE_TO_RESOURCE: dict[str, Resource] = {

--- a/rossum-agent/rossum_agent/tools/dynamic_tools.py
+++ b/rossum-agent/rossum_agent/tools/dynamic_tools.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
+
+import structlog
 
 from rossum_agent.rossum_mcp_integration.tools import mcp_tools_to_anthropic_format
 from rossum_agent.tools.core import get_context
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 
     from rossum_agent.rossum_mcp_integration.connection import MCPConnection
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass

--- a/rossum-agent/rossum_agent/tools/file_tools.py
+++ b/rossum-agent/rossum_agent/tools/file_tools.py
@@ -6,14 +6,14 @@ Read/write tools for the agent's output directory and workspace files.
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 
+import structlog
 from anthropic import beta_tool
 
 from rossum_agent.tools.core import get_context
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @beta_tool

--- a/rossum-agent/rossum_agent/tools/mock_pdf.py
+++ b/rossum-agent/rossum_agent/tools/mock_pdf.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import contextlib
 import json
-import logging
 import random
 import string
 import unicodedata
@@ -16,6 +15,7 @@ from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import structlog
 from anthropic import beta_tool
 from fpdf import FPDF
 
@@ -24,7 +24,7 @@ from rossum_agent.tools.core import get_context
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Override values can be str, int, or float — converted to str before use
 OverrideValue = str | int | float

--- a/rossum-agent/rossum_agent/tools/python_exec.py
+++ b/rossum-agent/rossum_agent/tools/python_exec.py
@@ -6,13 +6,13 @@ import ast
 import functools
 import io
 import json
-import logging
 from contextlib import redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
 import pandas
+import structlog
 from anthropic import beta_tool
 
 from rossum_agent.tools.core import get_context
@@ -24,7 +24,7 @@ from rossum_agent.tools.subagents.mcp_helpers import call_mcp_tool as _call_mcp_
 if TYPE_CHECKING:
     from anthropic.types import ToolParam
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _MAX_CODE_LENGTH = 25000
 _SPREADSHEET_EXTENSIONS = frozenset({".xlsx", ".xls"})

--- a/rossum-agent/rossum_agent/tools/python_helpers/copilot/_shared.py
+++ b/rossum-agent/rossum_agent/tools/python_helpers/copilot/_shared.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import copy
 import json
-import logging
 import re
 import time
 
 import httpx
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _handle_api_error(e: Exception, func_name: str) -> str:

--- a/rossum-agent/rossum_agent/tools/python_helpers/copilot/automation_setup.py
+++ b/rossum-agent/rossum_agent/tools/python_helpers/copilot/automation_setup.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import json
-import logging
 
 import httpx
+import structlog
 
 from rossum_agent.tools.core import get_context
 from rossum_agent.tools.python_helpers.copilot._shared import _handle_api_error, _json_headers, _request_with_retry
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _AUTOMATION_SETUP_TIMEOUT = 60
 

--- a/rossum-agent/rossum_agent/tools/python_helpers/copilot/formula.py
+++ b/rossum-agent/rossum_agent/tools/python_helpers/copilot/formula.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
-import logging
 import re
 from typing import Literal
 
 import httpx
+import structlog
 
 from rossum_agent.tools.core import get_context
 from rossum_agent.tools.python_helpers.copilot._shared import (
@@ -20,7 +20,7 @@ from rossum_agent.tools.python_helpers.copilot._shared import (
 
 FormulaFieldType = Literal["string", "number", "date", "enum"]
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _SUGGEST_FORMULA_TIMEOUT = 60
 

--- a/rossum-agent/rossum_agent/tools/python_helpers/copilot/lookup.py
+++ b/rossum-agent/rossum_agent/tools/python_helpers/copilot/lookup.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 import copy
 import json
-import logging
 import re
 
 import httpx
 import jq as jq_lib  # ty: ignore[unresolved-import] - no type stubs for jq
+import structlog
 
 from rossum_agent.tools.core import get_context
 from rossum_agent.tools.python_helpers.copilot._shared import (
@@ -28,7 +28,7 @@ from rossum_agent.tools.python_helpers.copilot._shared import (
 )
 from rossum_agent.tools.utils import truncate_output
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _SUGGEST_COMPUTED_FIELD_TIMEOUT = 60
 _EVALUATE_COMPUTED_FIELDS_TIMEOUT = 60

--- a/rossum-agent/rossum_agent/tools/python_helpers/copilot/rule.py
+++ b/rossum-agent/rossum_agent/tools/python_helpers/copilot/rule.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import json
-import logging
 
 import httpx
+import structlog
 
 from rossum_agent.tools.core import get_context
 from rossum_agent.tools.python_helpers.copilot._shared import _handle_api_error, _json_headers, _request_with_retry
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _SUGGEST_RULE_TIMEOUT = 60
 

--- a/rossum-agent/rossum_agent/tools/python_helpers/master_data_hub.py
+++ b/rossum-agent/rossum_agent/tools/python_helpers/master_data_hub.py
@@ -7,9 +7,9 @@ complementing the lookup field tools in lookup.py.
 from __future__ import annotations
 
 import json
-import logging
 
 import httpx
+import structlog
 
 from rossum_agent.tools.core import get_context
 from rossum_agent.tools.python_helpers.copilot._shared import (
@@ -25,7 +25,7 @@ from rossum_agent.tools.python_helpers.copilot._shared import (
 )
 from rossum_agent.tools.utils import truncate_output
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _extract_dataset_name(item: dict) -> str:

--- a/rossum-agent/rossum_agent/tools/skills.py
+++ b/rossum-agent/rossum_agent/tools/skills.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import json
-import logging
 
+import structlog
 from anthropic import beta_tool
 
 from rossum_agent.agent.skills import get_skill, get_skill_registry
 from rossum_agent.tools.dynamic_tools import load_tool, mark_skill_loaded
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def _auto_load_tools(tool_names: list[str]) -> str | None:

--- a/rossum-agent/rossum_agent/tools/subagents/base.py
+++ b/rossum-agent/rossum_agent/tools/subagents/base.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+import structlog
 
 if TYPE_CHECKING:
     from typing import Any
@@ -18,7 +19,7 @@ from rossum_agent.tools.core import (
 )
 from rossum_agent.utils import add_message_cache_breakpoint
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass

--- a/rossum-agent/rossum_agent/tools/subagents/elis_docs.py
+++ b/rossum-agent/rossum_agent/tools/subagents/elis_docs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 import tempfile
@@ -13,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import jq
+import structlog
 from anthropic import beta_tool
 
 from rossum_agent.tools.subagents.base import SubAgent, SubAgentConfig
@@ -21,7 +21,7 @@ from rossum_agent.tools.utils import truncate_output
 if TYPE_CHECKING:
     from typing import Any
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # OpenAPI spec paths & output limits

--- a/rossum-agent/rossum_agent/tools/subagents/knowledge_base/agent.py
+++ b/rossum-agent/rossum_agent/tools/subagents/knowledge_base/agent.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import TYPE_CHECKING
 
+import structlog
 from anthropic import beta_tool
 
 from rossum_agent.tools.data_tools import run_jq
@@ -31,7 +31,7 @@ from rossum_agent.tools.subagents.knowledge_base.tools import (
 if TYPE_CHECKING:
     from typing import Any
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _TOOL_RESULT_LIMIT = 15000
 _TOOL_RESULT_INNER_LIMIT = 12000

--- a/rossum-agent/rossum_agent/tools/subagents/knowledge_base/tools.py
+++ b/rossum-agent/rossum_agent/tools/subagents/knowledge_base/tools.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import ast
 import io
 import json
-import logging
 import re
 from contextlib import redirect_stdout
 
+import structlog
 from anthropic import beta_tool
 
 from rossum_agent.tools.subagents.knowledge_base.cache import cache
@@ -20,7 +20,7 @@ from rossum_agent.tools.subagents.knowledge_base.ranking import (
     rank_article,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 _GREP_MATCH_LIMIT = 200
 _GREP_OUTPUT_LIMIT = 50000

--- a/rossum-agent/rossum_agent/tools/subagents/mcp_helpers.py
+++ b/rossum-agent/rossum_agent/tools/subagents/mcp_helpers.py
@@ -6,16 +6,17 @@ Provides common utilities for calling MCP tools from synchronous thread contexts
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 from typing import TYPE_CHECKING
+
+import structlog
 
 from rossum_agent.tools.core import get_context
 
 if TYPE_CHECKING:
     from typing import Any
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def call_mcp_tool(name: str, arguments: dict[str, Any], timeout: int = 60) -> Any:

--- a/rossum-agent/rossum_agent/tools/subagents/schema_patching.py
+++ b/rossum-agent/rossum_agent/tools/subagents/schema_patching.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 
 import copy
 import json
-import logging
 import re
 import time
 from dataclasses import asdict, is_dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
+
+import structlog
 
 if TYPE_CHECKING:
     from typing import Any
@@ -36,7 +37,7 @@ from rossum_agent.tools.subagents.base import (
 )
 from rossum_agent.tools.subagents.mcp_helpers import call_mcp_tool
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class SchemaFieldType(StrEnum):

--- a/rossum-agent/rossum_agent/valkey_client.py
+++ b/rossum-agent/rossum_agent/valkey_client.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 import os
 
+import structlog
 import valkey
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class ValkeyConnection:

--- a/rossum-agent/tests/agent/test_tool_execution.py
+++ b/rossum-agent/tests/agent/test_tool_execution.py
@@ -305,6 +305,43 @@ class TestExecuteTool:
         assert "Connection failed" in result.content
 
     @pytest.mark.asyncio
+    async def test_logs_completion_with_duration_on_success(self, caplog):
+        """Test that successful tool calls emit tool_call.completed with duration."""
+        agent = self._create_agent()
+        agent.mcp_connection.call_tool.return_value = "ok"
+
+        tool_call = ToolCall(id="tc_1", name="some_tool", arguments={})
+
+        with caplog.at_level("INFO", logger="rossum_agent.agent.tool_execution"):
+            await self._get_final_result(agent, tool_call)
+
+        completed = [r for r in caplog.records if "tool_call.completed" in r.getMessage()]
+        assert len(completed) == 1
+        event = completed[0].msg
+        assert event["tool_name"] == "some_tool"
+        assert event["status"] == "success"
+        assert isinstance(event["duration_seconds"], float)
+
+    @pytest.mark.asyncio
+    async def test_logs_failure_with_duration_on_error(self, caplog):
+        """Test that failed tool calls emit tool_call.failed with duration and error_type."""
+        agent = self._create_agent()
+        agent.mcp_connection.call_tool.side_effect = RuntimeError("boom")
+
+        tool_call = ToolCall(id="tc_1", name="bad_tool", arguments={})
+
+        with caplog.at_level("WARNING", logger="rossum_agent.agent.tool_execution"):
+            await self._get_final_result(agent, tool_call)
+
+        failed = [r for r in caplog.records if "tool_call.failed" in r.getMessage()]
+        assert len(failed) == 1
+        event = failed[0].msg
+        assert event["tool_name"] == "bad_tool"
+        assert event["status"] == "error"
+        assert event["error_type"] == "RuntimeError"
+        assert isinstance(event["duration_seconds"], float)
+
+    @pytest.mark.asyncio
     async def test_spills_long_content_to_file(self):
         """Test that long tool output is spilled to a workspace file."""
         agent = self._create_agent()

--- a/rossum-agent/tests/conftest.py
+++ b/rossum-agent/tests/conftest.py
@@ -1,3 +1,9 @@
 """Root test configuration for rossum-agent tests."""
 
 from __future__ import annotations
+
+from rossum_mcp.logging_config import LogFormat, LogLevel, setup_logging
+
+# Route structlog and stdlib loggers through the shared setup so tests see the
+# same timestamps, level formatting, and contextvars as production.
+setup_logging(log_level=LogLevel.INFO, log_format=LogFormat.CONSOLE)

--- a/rossum-mcp/rossum_mcp/logging_config.py
+++ b/rossum-mcp/rossum_mcp/logging_config.py
@@ -69,8 +69,8 @@ def setup_logging(
     return root_logger
 
 
-def _get_processors(log_format: LogFormat) -> list:
-    common = [
+def _get_processors(log_format: LogFormat) -> list[structlog.types.Processor]:
+    common: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.stdlib.add_log_level,
@@ -82,6 +82,7 @@ def _get_processors(log_format: LogFormat) -> list:
     if log_format == LogFormat.CONSOLE:
         return [
             *common,
+            structlog.processors.format_exc_info,
             structlog.processors.UnicodeDecoder(),
             structlog.dev.ConsoleRenderer(),
         ]


### PR DESCRIPTION
Replace stdlib logging.getLogger with structlog.get_logger across rossum_agent modules, add structured tool_call.started/completed/failed events with duration and error_type in tool_execution, and route test conftests through the shared logging setup.
